### PR TITLE
Configure Next.js built-in i18n

### DIFF
--- a/automatizacion/app/page.tsx
+++ b/automatizacion/app/page.tsx
@@ -1,6 +1,0 @@
-// app/page.tsx
-import { redirect } from "next/navigation";
-
-export default function Home() {
-	redirect("/es"); // redirige automáticamente a la versión en español
-}

--- a/automatizacion/next.config.ts
+++ b/automatizacion/next.config.ts
@@ -1,7 +1,11 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-	/* config options here */
+  i18n: {
+    locales: ["en", "es", "pt"],
+    defaultLocale: "es",
+    localeDetection: true,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- configure Next.js internationalized routing for English, Spanish, and Portuguese
- remove custom language detection and root redirect to rely on framework features

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist`)*

------
https://chatgpt.com/codex/tasks/task_e_68938a2f29848331bb8bc7f06e055a22